### PR TITLE
'Fix' windows compatibility and use of configfile when specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ cmake_install.cmake
 install_manifest.txt
 CTestTestfile.cmake
 Testing/
+out/

--- a/src/org/editorconfig/core/EditorConfig.java
+++ b/src/org/editorconfig/core/EditorConfig.java
@@ -1,7 +1,18 @@
 package org.editorconfig.core;
 
-import java.io.*;
-import java.util.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -82,20 +93,22 @@ public class EditorConfig {
     Map<String, String> options = new LinkedHashMap<String, String>();
     try {
       boolean root = false;
-      String dir = new File(filePath).getParent();
+      String dir = new File(filePath).getAbsolutePath();
       while (dir != null && !root) {
-        String configPath = dir + "/" + configFilename;
+        String configPath = dir + File.separator + configFilename;
         if (new File(configPath).exists()) {
           FileInputStream stream = new FileInputStream(configPath);
           InputStreamReader reader = new InputStreamReader(stream, "UTF-8");
           BufferedReader bufferedReader = new BufferedReader(reader);
           try {
-            root = parseFile(bufferedReader, dir + "/", filePath, options);
+            root = parseFile(bufferedReader, dir + File.separator, filePath, options);
           } finally {
             bufferedReader.close();
             reader.close();
             stream.close();
           }
+        } else {
+            throw new FileNotFoundException();
         }
         options.putAll(oldOptions);
         oldOptions = options;
@@ -217,6 +230,7 @@ public class EditorConfig {
   }
 
   static boolean filenameMatches(String configDirname, String pattern, String filePath) {
+    filePath =  filePath.replaceAll("\\\\", "/");
     pattern = pattern.replace(File.separatorChar, '/');
     pattern = pattern.replaceAll("\\\\#", "#");
     pattern = pattern.replaceAll("\\\\;", ";");


### PR DESCRIPTION
# 1
Before: When I tried to use a specific name instead of .editorconfig it was not working once it was necessary to pass the filePath with the file name. So the variable `configFilename` was kind of useless (not being considered after all)

Now: Now i just pass the name of the path where the file is located and the name of the file is specified in the constructor if different of .editorconfig.

# 2
Before: Windows path separator was not supported once is was hardcoded with "/" and not being considered in the `filenameMatches` Method.

Now: windows path is supported

# 3 
Before: When there were no file it was not able to know and handle it.

Now: It throws a `FileNotFoundException` which is encapsulated in a `EditorConfigException` and I can validate the cause to handle this behavior.