### PR TITLE
necessary adaptions to publish to MavenCentral

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <configuration>
           <serverId>ossrh</serverId>
           <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>false</autoReleaseAfterClose>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
   <version>0.12.1.Final-SNAPSHOT</version>
 
   <name>EditorConfig Core</name>
+  <description>EditorConfig core library ported to Java</description>
   <url>http://editorconfig.org</url>
   <inceptionYear>2014</inceptionYear>
   <licenses>
@@ -14,6 +15,21 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <developers>
+    <developer>
+      <name>Dennis Ushakov</name>
+      <email>dennis.ushakov@gmail.com</email>
+      <organization>JetBrains</organization>
+      <organizationUrl>https://github.com/denofevil</organizationUrl>
+    </developer>
+    <developer>
+      <name>Peter Palage</name>
+      <email>ppalaga@redhat.com</email>
+      <organization>Red Hat</organization>
+      <organizationUrl>https://github.com/ppalaga</organizationUrl>
+    </developer>
+  </developers>
 
   <mailingLists>
     <mailingList>
@@ -46,6 +62,13 @@
     <maven.compiler.target>1.6</maven.compiler.target>
     <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
   </properties>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
 
   <build>
     <!-- Ordering: alphabetic by groupId and artifactId -->
@@ -94,13 +117,53 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.5</version>
+        <version>1.6.7</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>
           <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          <autoReleaseAfterClose>false</autoReleaseAfterClose>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9.1</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.5</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Changes needed to deploy the artifact to Maven Central (plus Sonatype Nexus account and registered GPG key being available), see #6.

I used these guides to do the changes:
- http://central.sonatype.org/pages/requirements.html#sufficient-metadata
- http://central.sonatype.org/pages/apache-maven.html#deploying-to-ossrh-with-apache-maven-introduction

I tested it by deploying to Maven Central (with a different group name), as I need it available in JCenter to be able to release a Gradle plugin that depends on it. But it would surely better to have an official version out.