### PR TITLE
Introduce StreamProvider

### DIFF
--- a/src/main/java/org/editorconfig/core/provider/FileStreamProvider.java
+++ b/src/main/java/org/editorconfig/core/provider/FileStreamProvider.java
@@ -1,0 +1,23 @@
+package org.editorconfig.core.provider;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+
+public class FileStreamProvider implements StreamProvider {
+  @Override
+  public InputStream openStream(String filePath) {
+    try{
+      if (new File(filePath).exists()){
+        return new FileInputStream(filePath);
+      }
+      else {
+        return null;
+      }
+    }
+    catch (FileNotFoundException ex){
+      return null;
+    }
+  }
+}

--- a/src/main/java/org/editorconfig/core/provider/StreamProvider.java
+++ b/src/main/java/org/editorconfig/core/provider/StreamProvider.java
@@ -1,0 +1,12 @@
+package org.editorconfig.core.provider;
+
+import java.io.InputStream;
+
+public interface StreamProvider {
+  /**
+   * open InputStream for specified path
+   * @param filePath file path to open file.
+   * @return opened InputStream
+   */
+  InputStream openStream(String filePath);
+}


### PR DESCRIPTION
Hi! I'm [GitBucket](https://github.com/gitbucket/gitbucket) developer. GitBucket is open source Git platform powered by Scala. It looks like as GitHub. It has online git repository browser and online file editor.

I was interested in making GitBucket correspond to Editorconfig. But, current implementation is based on local filesystem's file. So I introduced `StreamProvider` by this PR. I also wrote `JGitProvider` in my branch of GitBucket. see [here](https://github.com/kounoike/gitbucket/blob/test-editorconfig/src/main/java/editorconfig/JGitProvider.java)

If this PR is merged and it released to maven, I can make EditorConfig support PR to GitBucket.