### PR TITLE
Revert "Don't substitute indent_size with "tab" if it's not specified…

### DIFF
--- a/src/main/java/org/editorconfig/core/EditorConfig.java
+++ b/src/main/java/org/editorconfig/core/EditorConfig.java
@@ -175,6 +175,13 @@ public class EditorConfig {
       }
     }
 
+    // Set indent_size to "tab" if indent_size is unspecified and
+    // indent_style is set to "tab".
+    if ("tab".equals(options.get("indent_style")) && !options.containsKey("indent_size") &&
+        compareVersions(version, "0.10.0") >= 0) {
+      options.put("indent_size", "tab");
+    }
+
     // Set tab_width to indent_size if indent_size is specified and
     // tab_width is unspecified
     String indent_size = options.get("indent_size");


### PR DESCRIPTION
… explicitly"

This reverts commit e9e010dbb47da52d365cccd958ea19c97c5c631e.

This reverted commit breaks CI.

cc @dyadix 